### PR TITLE
Improve transcription alignment

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,51 +1,63 @@
 import re
 import string
+from difflib import SequenceMatcher
 
 def align_transcription_to_words(strd_wrd_sgmnt, transcription):
-    # Treat words inside the brackets as single word
-    transcription = re.sub(r'\[([^]]+)\]', lambda match: "[" + match.group(1).replace(" ", "_") + "]", transcription) 
+    """Align a transcription to the intervals returned by forced alignment.
 
-    # Tokenize the transcription into words
+    The function attempts to pair words from ``transcription`` with the
+    intervals in ``strd_wrd_sgmnt``.  If the number of words does not match the
+    number of intervals, ``SequenceMatcher`` is used to find the best mapping
+    between the two sequences.
+    """
+
+    # Treat words inside the brackets as single word
+    transcription = re.sub(r"\[([^]]+)\]", lambda m: "[" + m.group(1).replace(" ", "_") + "]", transcription)
+
+    # Tokenize the transcription into words and clean them
     words = transcription.split()
-    # Remove empty elements and elements containing only punctuation
-    words = [s for s in words if s and not all(char in string.punctuation for char in s)]
-    # Remove elements containing only '–', '+', '-'
-    words = [s for s in words if not (s in ['-', '+', '–'])]
-    # Remove empty or whitespace-only word intervals
+    words = [w for w in words if w and not all(c in string.punctuation for c in w)]
+    words = [w for w in words if w not in ["-", "+", "–"]]
+
+    # Remove empty or whitespace-only word intervals from FA output
     strd_wrd_sgmnt = [interval for interval in strd_wrd_sgmnt if interval[2].strip()]
 
+    # If the numbers already match, simply zip them together
     if len(words) == len(strd_wrd_sgmnt):
-        concatenated_intervals = strd_wrd_sgmnt
-    else:
-        # Concatenate the tuples from strd_wrd_sgmnt when they are part of the same word in words
-        concatenated_intervals = []
-        interval_index = 0
-        for i, word in enumerate(words):
-            # Start with the initial interval
-            if interval_index >= len(strd_wrd_sgmnt):
-                break
-            start_time, end_time, combined_word = strd_wrd_sgmnt[interval_index]
-            interval_index += 1
-            dash_count_word = sum(1 for i in range(1,len(word) - 1) if word[i] in ['-','&'] and not word[i + 1] in '.,;:!?')
-            dash_count_sgmnt = sum(1 for i in range(1,len(combined_word) - 1) if combined_word[i] in ['-','&'] and not combined_word[i + 1] in '.,;:!?')
-            dash_count = dash_count_word - dash_count_sgmnt
-            # Concatenate additional intervals
-            for _ in range(dash_count):
-                end_time = strd_wrd_sgmnt[interval_index][1]
-                combined_word += strd_wrd_sgmnt[interval_index][2]
-                interval_index += 1
-            concatenated_intervals.append((start_time, end_time, combined_word))
+        return [(interval[0], interval[1], word) for interval, word in zip(strd_wrd_sgmnt, words)]
 
-    # Ensure word count matches
-    if len(words) != len(concatenated_intervals):
-        words_fa = [t[-1] for t in concatenated_intervals]
-        print("\n".join(f"{a} {b}" for a, b in zip(words, words_fa)))
-        raise ValueError("Word count in transcription and TextGrid do not match.")
-    
-    # Associate pog transcription words with the strd-wrd-sgmnt intervals
-    transcription_intervals = [
-        (interval[0], interval[1], word) 
-        for interval, word in zip(concatenated_intervals, words)
-    ]
-    
-    return transcription_intervals
+    def _clean(word: str) -> str:
+        """Lower-case ``word`` and strip punctuation for comparison."""
+        return re.sub(f"[{re.escape(string.punctuation)}]", "", word).lower()
+
+    fa_words = [interval[2] for interval in strd_wrd_sgmnt]
+    cleaned_fa = [_clean(w) for w in fa_words]
+    cleaned_words = [_clean(w) for w in words]
+
+    sm = SequenceMatcher(None, cleaned_fa, cleaned_words)
+    aligned = []
+    for tag, i1, i2, j1, j2 in sm.get_opcodes():
+        if tag == "equal":
+            for off in range(i2 - i1):
+                start, end, _ = strd_wrd_sgmnt[i1 + off]
+                aligned.append((start, end, words[j1 + off]))
+        elif tag == "replace":
+            start = strd_wrd_sgmnt[i1][0]
+            end = strd_wrd_sgmnt[i2 - 1][1]
+            aligned.append((start, end, " ".join(words[j1:j2])))
+        elif tag == "delete":
+            # No transcription word for these intervals
+            for idx in range(i1, i2):
+                aligned.append(strd_wrd_sgmnt[idx])
+        elif tag == "insert":
+            # Extra words without intervals -> attach to previous segment
+            extra = " ".join(words[j1:j2])
+            if aligned:
+                s, e, prev = aligned[-1]
+                aligned[-1] = (s, e, prev + " " + extra)
+            else:
+                # If at the very beginning attach to the first interval
+                start, end, _ = strd_wrd_sgmnt[0]
+                aligned.append((start, end, extra))
+
+    return aligned


### PR DESCRIPTION
## Summary
- handle mismatched word counts when aligning text to FA intervals

## Testing
- `python -m py_compile utils.py`


------
https://chatgpt.com/codex/tasks/task_b_684bce9194f4833394a3ff5b8a3d5138