### PR TITLE
Add sonority computation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Similary, other tiers can be added. A list of implemented tiers and their brief 
 
 ## Acoustic Measurements
 
-The script [acoustic_measurements.py](acoustic_measurements.py) computes various acoustic measurements from a given TextGrid file and WAV audio file, extracting phoneme durations, pitch-related features, formants, intensity, VOT (Voice Onset Time), COG (Center of Gravity), and related annotations. The computed values are then stored in a CSV file for analysis and further processing.
+The script [acoustic_measurements.py](acoustic_measurements.py) computes various acoustic measurements from a given TextGrid file and WAV audio file, extracting phoneme durations, pitch-related features, formants, intensity, sonority, VOT (Voice Onset Time), COG (Center of Gravity), and related annotations. The computed values are then stored in a CSV file for analysis and further processing.
 
 **Usage:**
 
@@ -109,6 +109,7 @@ The output CSV file will contain the following columns for each phoneme:
 * `F3Formant`: The F3 formant frequency (Hz)
 * `F4Formant`: The F4 formant frequency (Hz)
 * `Intensity`: The average intensity of the phoneme (dB)
+* `Sonority`: The sonority value of the phoneme
 * `VOT`: The voice onset time (seconds)
 * `COG`: The centroid of gravity of the phoneme (Hz)
 * `PreviousPhone`: The phoneme preceding the current phoneme

--- a/README.sl.md
+++ b/README.sl.md
@@ -68,7 +68,7 @@ ki doda novo vrstco s časovnimi intervali na nivoju zlogov v izhodno datoteko T
 
 ## Akustične Meritve
 
-Skripta [acoustic_measurements.py](acoustic_measurements.py) izračuna različne akustične meritve iz danih datotek TextGrid in WAV, kot so trajanje fonemov, akustične lastnosti povezane z višino tona, formante, glasnost, VOT (čas do začetka zvenečnosti), COG (težišče) in sorodne oznake. Izračunane vrednosti se nato shranijo v datoteko CSV za nadaljnjo analizo in obdelavo.
+Skripta [acoustic_measurements.py](acoustic_measurements.py) izračuna različne akustične meritve iz danih datotek TextGrid in WAV, kot so trajanje fonemov, akustične lastnosti povezane z višino tona, formante, glasnost, sonornost, VOT (čas do začetka zvenečnosti), COG (težišče) in sorodne oznake. Izračunane vrednosti se nato shranijo v datoteko CSV za nadaljnjo analizo in obdelavo.
 
 **Uporaba:**
 
@@ -95,6 +95,7 @@ Izhodna datoteka CSV vsebuje naslednje stolpce za posamezen fonem:
 * `F3Formant`: Frekvenca tretjega formanta (v Hz)
 * `F4Formant`: Frekvenca četrtega formanta (v Hz)
 * `Intensity`: Povprečna intenzivnost fonema (v dB)
+* `Sonority`: Vrednost sonornosti fonema
 * `VOT`: Čas do začetka zvenečnosti (v sekundah)
 * `COG`: Težišče fonema (v Hz)
 * `PreviousPhone`: Fonem pred trenutnim fonemom


### PR DESCRIPTION
## Summary
- compute sonority values with `extract_sonority`
- output the sonority value for each phone or syllable
- document the new measurement in both English and Slovenian READMEs

## Testing
- `python -m py_compile acoustic_measurements.py extract_sonority.py`

------
https://chatgpt.com/codex/tasks/task_b_685518c713c48333b6ad0a50de82f60b